### PR TITLE
Closing dead websockets on the client

### DIFF
--- a/datachannel.js
+++ b/datachannel.js
@@ -153,7 +153,7 @@ function DCPF_install(ws_url)
               case 'create.native':
                 // Close the ad-hoc signaling channel
                 try {
-                  this._signaling.close();
+                  self._signaling.close();
                 } catch (e) { };
 
                 // Make native DataChannels to be created by default


### PR DESCRIPTION
I've tweaked datachannel.js so that all websockets it creates are closeable. Currently if a datachannel is established and then later close()'d the websocket will stay open. If you're working with a lot of peer's you quickly get a crazy number of dead (yet still connected) websockets.
